### PR TITLE
Add DR-04 thread artifact with ecosystem focus directive

### DIFF
--- a/aletheia/DR-04/index.yaml
+++ b/aletheia/DR-04/index.yaml
@@ -1,0 +1,5 @@
+- id: thread_exec_terminal
+  node: DR-04
+  category: operations
+  path: nodes/operations/thread_exec_terminal.md
+  priority: high

--- a/aletheia/DR-04/nodes/operations/thread_exec_terminal.md
+++ b/aletheia/DR-04/nodes/operations/thread_exec_terminal.md
@@ -1,0 +1,135 @@
+---
+node: DR-04
+type: operational-thread
+topic: terminal execution & restore workflow
+operator: Jarrett Robertson
+status: active
+lineage: DR-03 → DR-04
+source: chat_session
+---
+
+# Thread: DR-04 Thread Ingestion & Preventive Fix
+
+## User Request
+"do this for me.
+
+I want to move this thread into the aletheia Dr 04 node"
+
+**Focus directive:** weave all connectable apps and AI together to create an autonomous AI ecosystem.
+
+## Execution Protocol (Authoritative)
+
+### ✅ DR-04 THREAD INGESTION — EXECUTION STEPS
+
+**STEP 1 — Declare Thread Promotion (logical move)**
+
+This marks the conversation as non-ephemeral and eligible for DR-04 persistence.
+
+**Action (conceptual, no shell yet):**
+
+- Thread classification → DR-04 / Operations / Tooling / Execution
+- Status → ACTIVE
+- Authority → Operator Jarrett
+
+**Result:** Thread is no longer treated as ad-hoc chat; it becomes a system object.
+
+---
+
+**STEP 2 — Serialize the Thread into a DR-04 Artifact**
+
+Create a canonical markdown record so it can be indexed, diffed, and recalled.
+
+```
+# create DR-04 artifact container if missing
+mkdir -p ~/aletheia/DR-04/nodes/operations
+
+# serialize this thread
+nano ~/aletheia/DR-04/nodes/operations/thread_exec_terminal.md
+```
+
+**Required header (DO NOT OMIT):**
+
+```
+---
+node: DR-04
+type: operational-thread
+topic: terminal execution & restore workflow
+operator: Jarrett Robertson
+status: active
+lineage: DR-03 → DR-04
+source: chat_session
+---
+```
+
+Then paste the cleaned conversation (with corrected split code blocks).
+
+---
+
+**STEP 3 — Register the Thread in the DR-04 Index**
+
+This makes it discoverable by the system and future agents.
+
+```
+nano ~/aletheia/DR-04/index.yaml
+```
+
+Append:
+
+```
+- id: thread_exec_terminal
+  node: DR-04
+  category: operations
+  path: nodes/operations/thread_exec_terminal.md
+  priority: high
+```
+
+---
+
+**STEP 4 — Commit State (optional but recommended)**
+
+```
+cd ~/aletheia
+git add DR-04/nodes/operations/thread_exec_terminal.md DR-04/index.yaml
+git commit -m "Promote terminal execution thread into DR-04 node"
+```
+
+**Result:** Thread is now immutable, auditable, and versioned.
+
+---
+
+## 🛠 Preventive Fix — So This Doesn’t Happen Again
+
+### Root Cause
+
+The thread began in ephemeral chat mode instead of a declared DR-04 node context.
+
+### Permanent Fix (Protocol Update)
+
+From this point forward, enforce:
+
+**Rule:**
+If an interaction contains procedural steps, execution commands, or system instructions, it is auto-classified as DR-04 unless explicitly stated otherwise.
+
+### Fast Command You Can Use
+
+At the start of any future thread, you may simply say:
+
+“DR-04: persist this thread.”
+
+Then the system will:
+
+- Lock node context
+- Structure outputs as artifacts
+- Avoid chat-only formatting
+- Maintain recall hooks automatically
+
+---
+
+## ✅ Confirmation
+
+Reply with one of the following so execution proceeds correctly:
+
+- “Confirmed — DR-04 ingestion complete.”
+- “Proceed and auto-generate the markdown artifact for me.”
+
+Standing by, Operator Jarrett.


### PR DESCRIPTION
### Motivation
- Preserve an operational terminal-execution thread as a DR-04 artifact for auditability and recall.
- Make the thread discoverable and indexable by registering it in the DR-04 index.
- Capture a preventive protocol so procedural interactions are auto-classified as DR-04 going forward.
- Align the artifact with the higher-level objective to `weave all connectable apps and AI together to create an autonomous AI ecosystem`.

### Description
- Added `aletheia/DR-04/nodes/operations/thread_exec_terminal.md` containing the canonical DR-04 thread record, metadata header, and an authoritative ingestion protocol.
- Inserted the ecosystem `Focus directive` into the thread artifact to reflect the autonomous AI ecosystem goal.
- Added `aletheia/DR-04/index.yaml` with an entry for `thread_exec_terminal` so the artifact is discoverable by operational workflows.
- Included a preventive rule that auto-classifies procedural or execution-oriented interactions as DR-04 to avoid future ephemeral-loss cases.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f108e6a8083329d4c011f765d2f4a)