### PR TITLE
Containerize trading stack: collector, signal-engine, and paper-trade services

### DIFF
--- a/collector/Dockerfile
+++ b/collector/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY binance_collector.py .
+RUN pip install --no-cache-dir websockets
+VOLUME ["/data"]
+CMD ["python", "binance_collector.py"]

--- a/collector/binance_collector.py
+++ b/collector/binance_collector.py
@@ -1,0 +1,48 @@
+import asyncio
+import json
+import os
+from datetime import datetime, timezone
+
+import websockets
+
+SYMBOL = os.getenv("BINANCE_SYMBOL", "btcusdt")
+INTERVAL = os.getenv("BINANCE_INTERVAL", "1m")
+DATA_PATH = os.getenv("DATA_PATH", "/data")
+
+
+async def stream_candles() -> None:
+    url = (
+        f"wss://stream.binance.com:9443/ws/{SYMBOL}@kline_{INTERVAL}"
+    )
+    output_file = os.path.join(DATA_PATH, f"{SYMBOL}_klines.csv")
+    os.makedirs(DATA_PATH, exist_ok=True)
+
+    async with websockets.connect(url) as websocket, open(
+        output_file, "a", encoding="utf-8"
+    ) as handle:
+        while True:
+            message = await websocket.recv()
+            payload = json.loads(message)
+            kline = payload.get("k", {})
+            if not kline:
+                continue
+
+            close_time = datetime.fromtimestamp(
+                kline["T"] / 1000, tz=timezone.utc
+            ).isoformat()
+            row = ",".join(
+                [
+                    close_time,
+                    str(kline.get("o")),
+                    str(kline.get("h")),
+                    str(kline.get("l")),
+                    str(kline.get("c")),
+                    str(kline.get("v")),
+                ]
+            )
+            handle.write(row + "\n")
+            handle.flush()
+
+
+if __name__ == "__main__":
+    asyncio.run(stream_candles())

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,30 @@
+version: "3.9"
+
+services:
+  collector:
+    build: ./collector
+    container_name: collector
+    restart: always
+    volumes:
+      - ./data:/data
+
+  signal-engine:
+    build: ./signal
+    container_name: signal-engine
+    restart: always
+    environment:
+      - OPENAI_API_KEY=${OPENAI_API_KEY}
+    volumes:
+      - ./data:/data
+      - ./config:/config
+    depends_on:
+      - collector
+
+  paper-trade:
+    build: ./papertrade
+    container_name: paper-trade
+    restart: always
+    volumes:
+      - ./data:/data
+    depends_on:
+      - signal-engine

--- a/papertrade/Dockerfile
+++ b/papertrade/Dockerfile
@@ -1,0 +1,7 @@
+FROM debian:bookworm-slim
+RUN apt-get update && apt-get install -y bash awk bc && rm -rf /var/lib/apt/lists/*
+WORKDIR /app
+COPY analyze_trades.sh .
+RUN chmod +x analyze_trades.sh
+VOLUME ["/data"]
+CMD ["/bin/bash", "/app/analyze_trades.sh"]

--- a/papertrade/analyze_trades.sh
+++ b/papertrade/analyze_trades.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DATA_PATH="${DATA_PATH:-/data}"
+LOG_FILE="${DATA_PATH}/paper_trades.log"
+
+mkdir -p "${DATA_PATH}"
+
+echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] paper-trade started" >> "${LOG_FILE}"
+
+while true; do
+  if [[ -f "${DATA_PATH}/signal_engine.log" ]]; then
+    tail -n 5 "${DATA_PATH}/signal_engine.log" >> "${LOG_FILE}"
+  else
+    echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] waiting for signals" >> "${LOG_FILE}"
+  fi
+  sleep 60
+done

--- a/signal/Dockerfile
+++ b/signal/Dockerfile
@@ -1,0 +1,8 @@
+FROM debian:bookworm-slim
+RUN apt-get update && apt-get install -y bash curl jq bc && rm -rf /var/lib/apt/lists/*
+WORKDIR /app
+COPY price_check.sh .
+RUN chmod +x price_check.sh
+VOLUME ["/data", "/config"]
+ENV OPENAI_API_KEY=""
+CMD ["/bin/bash", "-lc", "/app/price_check.sh"]

--- a/signal/price_check.sh
+++ b/signal/price_check.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DATA_PATH="${DATA_PATH:-/data}"
+CONFIG_PATH="${CONFIG_PATH:-/config}"
+
+mkdir -p "${DATA_PATH}" "${CONFIG_PATH}"
+
+LOG_FILE="${DATA_PATH}/signal_engine.log"
+
+echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] signal-engine started" >> "${LOG_FILE}"
+
+# Placeholder loop for existing price_check/adaptive_tune logic.
+while true; do
+  if [[ -f "${DATA_PATH}/btcusdt_klines.csv" ]]; then
+    tail -n 1 "${DATA_PATH}/btcusdt_klines.csv" >> "${LOG_FILE}"
+  else
+    echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] waiting for collector data" >> "${LOG_FILE}"
+  fi
+  sleep 30
+done


### PR DESCRIPTION
### Motivation
- Isolate the trading components from the host Python environment by running them as separate containers with shared volumes for data and config.
- Provide a reproducible development/runtime layout for the collector, signal engine, and paper-trade processes so they can be restarted and composed easily.
- Streamline data flow by centralizing kline data and logs into a shared `/data` volume for downstream processing and inspection.

### Description
- Add `docker-compose.yml` that wires three services (`collector`, `signal-engine`, `paper-trade`) with shared volumes `./data:/data` and `./config:/config` and appropriate `depends_on` ordering.
- Add collector implementation `collector/binance_collector.py` and `collector/Dockerfile` that stream Binance kline websockets using the `websockets` package and append CSV rows to `/data/<symbol>_klines.csv` with support for `BINANCE_SYMBOL`, `BINANCE_INTERVAL`, and `DATA_PATH` environment variables.
- Add signal service `signal/price_check.sh` and `signal/Dockerfile` as a bootstrap placeholder that tails the latest kline into `signal_engine.log` and exposes `OPENAI_API_KEY` via environment.
- Add paper-trade service `papertrade/analyze_trades.sh` and `papertrade/Dockerfile` that consumes `signal_engine.log` and writes `paper_trades.log` to the shared `/data` volume.

### Testing
- No automated tests were executed for this change.
- The files were added and the project committed, but runtime verification (for example `docker compose up -d --build`) was not performed as part of automated testing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695df57d4a0c8332846d9818b502621f)