### PR TITLE
Expand agent tool catalog for app connectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,137 @@
+# Phantom Shell n8n AI Ecosystem
+
+This repository provides a starter template for wiring up an n8n automation that orchestrates OpenAI models with a Python microservice acting as a tool-execution agent. The goal is to combine multiple AI assistance capabilities (planning, tool execution, result summarisation) into a cohesive flow you can import into your n8n instance.
+
+## Components
+
+- **n8n Workflow (`workflows/ai-ecosystem.json`)**: An importable workflow that connects a webhook trigger to OpenAI for intent parsing, routes tasks to a Python agent for tool execution, and sends a summarised result back to the caller.
+- **Python Agent (`agent.py`)**: A lightweight FastAPI service that can be invoked from n8n to run custom Python tooling and call OpenAI. Extend this file with your own tools or retrieval logic.
+- **OpenAI Integration**: The workflow uses n8n's built-in OpenAI node for orchestration and the Python agent uses the `openai` Python SDK for downstream calls (e.g., function/tool calling, long-form responses).
+
+## Prerequisites
+
+- Python 3.10+
+- n8n (self-hosted or cloud) with access to the OpenAI node
+- An OpenAI API key with access to the models you need (update `model` fields as desired)
+
+Install Python dependencies locally:
+
+```bash
+pip install -r requirements.txt
+```
+
+Run the fast checks locally:
+
+```bash
+pytest
+```
+
+## Running the Python Agent
+
+1. Export your OpenAI key:
+   ```bash
+   export OPENAI_API_KEY=sk-...
+   ```
+2. Start the service (falls back to an offline summary if no key is configured):
+   ```bash
+   uvicorn agent:app --host 0.0.0.0 --port 5000
+   ```
+3. The agent will expose `POST /agent` for task execution. The n8n workflow is configured to call `http://host.docker.internal:5000/agent` (adjust to match your deployment).
+
+You can also run the service directly with Python:
+
+```bash
+python agent.py  # listens on 0.0.0.0:5000 with auto-reload
+```
+
+## Importing the n8n Workflow
+
+1. Open n8n and create a new workflow.
+2. Choose **Import from File** and select `workflows/ai-ecosystem.json`.
+3. Add an **OpenAI** credential in n8n and select it in both OpenAI nodes.
+4. For the **HTTP Request** node, adjust the URL to reach your Python agent (e.g., `http://localhost:5000/agent` if running n8n locally).
+5. Activate the workflow and hit the webhook URL shown in the **Webhook** node to start the flow.
+
+## How the Flow Works
+
+1. **Webhook** receives an incoming JSON payload with `task` and optional `context`.
+2. **Intent Planner (OpenAI)** interprets the task and prepares a structured request for the Python agent, including suggested tools/parameters.
+3. **Python Agent (HTTP Request)** forwards the structured task to the FastAPI service (`POST /agent`) where custom Python tools can run and where another OpenAI call can be made if needed.
+4. **Result Summariser (OpenAI)** takes the agent output and crafts a user-friendly response.
+5. **Return Response (Webhook Response)** returns the summary to the caller.
+
+## Extending the Agent
+
+- Use the built-in tool catalog in `run_tools` to connect multiple apps without editing the workflow:
+  - `http_request`: call any HTTP API (CRM, project tracker, DB proxy, webhook). Provide `params.url`, optional `params.method`, `params.headers`, `params.json`, or `params.data`.
+  - `slack_webhook`: send a message to Slack using `params.webhook_url` or the `SLACK_WEBHOOK_URL` environment variable, with an optional `params.message` (defaults to the instruction text).
+  - `echo`: always emitted so you can trace what the agent saw.
+- Add your own functions in `run_tools` for other systems (Notion, Jira, Airtable, search, vector DBs); the n8n planner passes `tool_specs` so you can route dynamically.
+- Use OpenAI's tool/function-calling in `run_openai_reasoning` to decide which tool to run based on the incoming `tool_specs`.
+- Update the n8n workflow with downstream delivery nodes (e.g., Slack/Email/HTTP) after the summariser to push results to your preferred channels.
+
+### Example `tool_specs` payloads
+
+Add these in the webhook payload (`tool_specs`) or via the Intent Planner node response in n8n:
+
+```json
+{
+  "task": "capture today’s status and post to Slack",
+  "context": {"project": "alpha"},
+  "tool_specs": [
+    {
+      "name": "http_request",
+      "params": {
+        "url": "https://status.internal/api/today",
+        "method": "GET",
+        "headers": {"Authorization": "Bearer <token>"}
+      }
+    },
+    {
+      "name": "slack_webhook",
+      "params": {
+        "message": "Status posted from Phantom Shell agent",
+        "webhook_url": "https://hooks.slack.com/services/..."  
+      }
+    }
+  ]
+}
+```
+
+The agent will fetch data from your API, summarize it, and post the summary to Slack—all within one request.
+
+## Security Notes
+
+- Keep your OpenAI key secret. In production, inject it via environment variables or a secrets manager.
+- Validate and sanitise any user-provided input in `agent.py` before running local tools.
+- When calling external systems, enforce timeouts in both n8n and the Python agent to avoid runaway tasks.
+
+### Safely providing your OpenAI API key
+
+You never need to share your key with anyone else to run this stack. Follow these steps instead:
+
+1. **Local env var (preferred):**
+   ```bash
+   # Do this only on your own machine/VM; never paste the key into chats or logs
+   export OPENAI_API_KEY=sk-...
+   ```
+   The FastAPI agent reads this variable at runtime and does not log it.
+
+2. **.env file for local dev (keep private):**
+   ```bash
+   echo "OPENAI_API_KEY=sk-..." > .env
+   ```
+   Load it with a tool like `direnv` or `python-dotenv` and ensure `.env` stays uncommitted.
+
+3. **Docker / n8n containers:** pass the key as an environment variable or Docker secret (e.g., `-e OPENAI_API_KEY=...` or `--env-file .env`). Inside n8n, create an **OpenAI** credential rather than hard-coding the key in nodes.
+
+4. **Rotation:** if a key is ever exposed, rotate it in the OpenAI dashboard and update the env var/secret—no code changes required.
+
+These steps keep the key on machines you control while enabling live OpenAI responses end-to-end.
+
+## Troubleshooting
+
+- If the HTTP Request node cannot reach the Python agent, confirm the hostname/port and that Docker networking allows access (`host.docker.internal` works for Docker Desktop; otherwise use the agent container IP or a bridge network alias).
+- For long responses, adjust `max_tokens` in the OpenAI nodes and `run_openai_reasoning`.
+- Use n8n's **Execution Log** to inspect the JSON exchanged between nodes.
+- Without an `OPENAI_API_KEY`, the agent returns an offline-friendly summary so you can test the full flow without an API call.

--- a/agent.py
+++ b/agent.py
@@ -1,0 +1,221 @@
+from __future__ import annotations
+
+import os
+from typing import Any, Dict, List, Optional
+
+import httpx
+from fastapi import FastAPI, HTTPException
+from openai import OpenAI
+from pydantic import BaseModel
+
+app = FastAPI(title="Phantom Shell Python Agent")
+
+
+def _get_openai_client() -> Optional[OpenAI]:
+    """Return an OpenAI client if a key is configured, otherwise None."""
+
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        return None
+
+    return OpenAI(api_key=api_key)
+
+
+class AgentRequest(BaseModel):
+    instruction: str
+    context: Optional[Dict[str, Any]] = None
+    tool_specs: Optional[List[Dict[str, Any]]] = None
+
+
+class AgentResponse(BaseModel):
+    result: str
+    raw_tool_outputs: Optional[List[Dict[str, Any]]] = None
+
+
+def _run_http_request(spec: Dict[str, Any]) -> Dict[str, Any]:
+    """Perform a simple HTTP request to connect with external apps/APIs.
+
+    The spec should include at least a `url`. Optional fields:
+    - method: HTTP verb (default GET)
+    - headers: dict of headers
+    - json/body/query params depending on your target API
+    """
+
+    params = spec.get("params", {}) or {}
+    url = params.get("url")
+    method = (params.get("method") or "GET").upper()
+    headers = params.get("headers")
+    json_payload = params.get("json")
+    data = params.get("data")
+    timeout = params.get("timeout", 10)
+
+    if not url:
+        return {
+            "tool": "http_request",
+            "status": "skipped",
+            "reason": "No URL provided",
+            "method": method,
+        }
+
+    try:
+        response = httpx.request(
+            method=method,
+            url=url,
+            headers=headers,
+            json=json_payload,
+            data=data,
+            timeout=timeout,
+        )
+        return {
+            "tool": "http_request",
+            "status": response.status_code,
+            "method": method,
+            "url": url,
+            "response_preview": response.text[:1000],
+            "headers": dict(response.headers),
+        }
+    except Exception as exc:  # noqa: BLE001
+        return {
+            "tool": "http_request",
+            "status": "error",
+            "method": method,
+            "url": url,
+            "error": str(exc),
+        }
+
+
+def _run_slack_webhook(spec: Dict[str, Any], default_message: str) -> Dict[str, Any]:
+    """Send a message to Slack via an incoming webhook if configured."""
+
+    params = spec.get("params", {}) or {}
+    webhook_url = params.get("webhook_url") or os.getenv("SLACK_WEBHOOK_URL")
+    message = params.get("message") or default_message
+
+    if not webhook_url:
+        return {
+            "tool": "slack_webhook",
+            "status": "skipped",
+            "reason": "No webhook URL provided; set SLACK_WEBHOOK_URL or pass params.webhook_url",
+            "message": message,
+        }
+
+    try:
+        response = httpx.post(webhook_url, json={"text": message}, timeout=params.get("timeout", 10))
+        return {
+            "tool": "slack_webhook",
+            "status": response.status_code,
+            "message": message,
+        }
+    except Exception as exc:  # noqa: BLE001
+        return {
+            "tool": "slack_webhook",
+            "status": "error",
+            "message": message,
+            "error": str(exc),
+        }
+
+
+def run_tools(instruction: str, context: Optional[Dict[str, Any]], tool_specs: Optional[List[Dict[str, Any]]]):
+    """Extend this function with your own tooling logic.
+
+    The default catalog includes:
+    - http_request: make an HTTP call to any app/API to fetch or post data.
+    - slack_webhook: send a message to Slack using an incoming webhook URL.
+    - echo: always present to reflect the instruction/context for tracing.
+    """
+
+    outputs: List[Dict[str, Any]] = []
+    specs = tool_specs or []
+
+    if not specs:
+        specs = [{"name": "echo", "params": {}}]
+
+    for spec in specs:
+        name = (spec.get("name") or "").lower()
+        if name == "http_request":
+            outputs.append(_run_http_request(spec))
+        elif name == "slack_webhook":
+            outputs.append(_run_slack_webhook(spec, default_message=instruction))
+        else:
+            outputs.append(
+                {
+                    "tool": "echo",
+                    "instruction": instruction,
+                    "context": context or {},
+                    "tool_specs": tool_specs or [],
+                }
+            )
+
+    return outputs
+
+
+def run_openai_reasoning(instruction: str, tool_outputs: List[Dict[str, Any]]) -> str:
+    """Use OpenAI to produce a consolidated answer and next-step guidance."""
+
+    client = _get_openai_client()
+
+    # Provide an offline-friendly summary when no OpenAI key is configured.
+    if client is None:
+        summary_lines = [
+            "OpenAI key not set – returning offline summary.",
+            f"Instruction: {instruction}",
+            f"Observed tool outputs ({len(tool_outputs)}): {tool_outputs}",
+            "Set an OPENAI_API_KEY environment variable (or .env secret) locally to enable live reasoning.",
+        ]
+        return "\n".join(summary_lines)
+
+    messages = [
+        {
+            "role": "system",
+            "content": "You are a senior orchestrator that summarises tool outputs and recommends the next action.",
+        },
+        {
+            "role": "user",
+            "content": f"Instruction: {instruction}\n\nTool outputs: {tool_outputs}",
+        },
+    ]
+
+    try:
+        response = client.chat.completions.create(
+            model="gpt-4o-mini",
+            messages=messages,
+            temperature=0.2,
+            max_tokens=300,
+        )
+        return response.choices[0].message.content
+    except Exception as exc:  # noqa: BLE001
+        fallback_lines = [
+            "OpenAI call failed – returning offline summary.",
+            f"Reason: {exc}",
+            f"Instruction: {instruction}",
+            f"Observed tool outputs ({len(tool_outputs)}): {tool_outputs}",
+            "Verify your OPENAI_API_KEY is set locally and that networking allows access to the OpenAI endpoint.",
+        ]
+        return "\n".join(fallback_lines)
+
+
+@app.post("/agent", response_model=AgentResponse)
+async def execute_agent(request: AgentRequest):
+    if not request.instruction:
+        raise HTTPException(status_code=400, detail="Instruction is required")
+
+    tool_outputs = run_tools(request.instruction, request.context, request.tool_specs)
+    reasoning = run_openai_reasoning(request.instruction, tool_outputs)
+
+    return AgentResponse(result=reasoning, raw_tool_outputs=tool_outputs)
+
+
+@app.get("/healthz")
+async def health() -> Dict[str, str]:
+    return {"status": "ok"}
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(
+        "agent:app",
+        host="0.0.0.0",
+        port=int(os.getenv("PORT", "5000")),
+        reload=True,
+    )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,6 @@
-
+fastapi>=0.111.0
+uvicorn>=0.30.0
+openai>=1.37.0
+pydantic>=2.7.0
+pytest>=8.2.0
+httpx>=0.27.0

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -1,0 +1,88 @@
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from agent import app
+from fastapi.testclient import TestClient
+
+
+def test_agent_offline_summary_when_no_api_key(monkeypatch):
+    # Ensure we operate without an OpenAI key so offline mode is exercised.
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    client = TestClient(app)
+    response = client.post(
+        "/agent",
+        json={"instruction": "demo instruction", "context": {"foo": "bar"}},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+
+    assert payload["raw_tool_outputs"][0]["tool"] == "echo"
+    assert "offline summary" in payload["result"].lower()
+    assert "demo instruction" in payload["result"]
+    assert "OPENAI_API_KEY" in payload["result"]
+
+
+def test_agent_executes_http_tool(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    # Avoid real network calls during tests.
+    def fake_request(method, url, headers=None, json=None, data=None, timeout=10):  # noqa: ANN001
+        class Response:  # pragma: no cover - simple stub
+            status_code = 202
+            text = "synthetic response"
+            headers = {"x-test": "1"}
+
+        return Response()
+
+    monkeypatch.setattr("agent.httpx.request", fake_request)
+
+    client = TestClient(app)
+    response = client.post(
+        "/agent",
+        json={
+            "instruction": "call api",
+            "tool_specs": [{"name": "http_request", "params": {"url": "https://example.com"}}],
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+
+    first_tool = payload["raw_tool_outputs"][0]
+    assert first_tool["tool"] == "http_request"
+    assert first_tool["status"] == 202
+
+
+def test_agent_slack_tool_skips_without_webhook(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("SLACK_WEBHOOK_URL", raising=False)
+
+    client = TestClient(app)
+    response = client.post(
+        "/agent",
+        json={
+            "instruction": "notify", "tool_specs": [{"name": "slack_webhook", "params": {"message": "hello"}}]
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    slack_output = payload["raw_tool_outputs"][0]
+
+    assert slack_output["tool"] == "slack_webhook"
+    assert slack_output["status"] == "skipped"
+    assert "webhook" in slack_output["reason"].lower()
+
+
+def test_healthcheck():
+    client = TestClient(app)
+    response = client.get("/healthz")
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}

--- a/workflows/ai-ecosystem.json
+++ b/workflows/ai-ecosystem.json
@@ -1,0 +1,167 @@
+{
+  "nodes": [
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "phantom-shell/ai-ecosystem",
+        "options": {
+          "responseContentType": "application/json"
+        }
+      },
+      "id": "1",
+      "name": "Webhook",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 1,
+      "position": [
+        -520,
+        200
+      ],
+      "webhookId": "phantom-shell-ai-ecosystem"
+    },
+    {
+      "parameters": {
+        "operation": "chat",
+        "model": "gpt-4o-mini",
+        "responseFormat": "json",
+        "systemMessage": "You are a planner that converts a natural language task into a structured tool request for a Python agent. Always return a JSON object with keys instruction, context, and tool_specs.",
+        "messages": {
+          "chatMessages": [
+            {
+              "text": "User task: {{$json.task}}\nOptional context: {{$json.context}}\nReturn JSON with instruction, context, tool_specs (tools you recommend the Python agent should run).",
+              "type": "user"
+            }
+          ]
+        }
+      },
+      "id": "2",
+      "name": "Intent Planner",
+      "type": "n8n-nodes-base.openAi",
+      "typeVersion": 2,
+      "position": [
+        -280,
+        200
+      ],
+      "credentials": {
+        "openAiApi": {
+          "id": "{{OPENAI_CREDENTIAL_ID}}",
+          "name": "OpenAI"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "requestMethod": "POST",
+        "url": "http://host.docker.internal:5000/agent",
+        "jsonParameters": true,
+        "options": {
+          "timeout": 120
+        },
+        "body": "={{$json}}"
+      },
+      "id": "3",
+      "name": "Python Agent",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4,
+      "position": [
+        -40,
+        200
+      ]
+    },
+    {
+      "parameters": {
+        "operation": "chat",
+        "model": "gpt-4o-mini",
+        "systemMessage": "You summarise the Python agent result for an end user and list recommended follow-up actions.",
+        "messages": {
+          "chatMessages": [
+            {
+              "text": "Task: {{$json.body.instruction}}\n\nContext: {{$json.body.context}}\n\nTool outputs: {{$json.body.raw_tool_outputs}}\n\nReasoning: {{$json.body.result}}\n\nProvide a concise summary and next steps.",
+              "type": "user"
+            }
+          ]
+        },
+        "options": {}
+      },
+      "id": "4",
+      "name": "Result Summariser",
+      "type": "n8n-nodes-base.openAi",
+      "typeVersion": 2,
+      "position": [
+        200,
+        200
+      ],
+      "credentials": {
+        "openAiApi": {
+          "id": "{{OPENAI_CREDENTIAL_ID}}",
+          "name": "OpenAI"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "respondWith": "lastNode",
+        "options": {
+          "responseContentType": "application/json"
+        }
+      },
+      "id": "5",
+      "name": "Webhook Response",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1,
+      "position": [
+        440,
+        200
+      ]
+    }
+  ],
+  "connections": {
+    "Webhook": {
+      "main": [
+        [
+          {
+            "node": "Intent Planner",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Intent Planner": {
+      "main": [
+        [
+          {
+            "node": "Python Agent",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Python Agent": {
+      "main": [
+        [
+          {
+            "node": "Result Summariser",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Result Summariser": {
+      "main": [
+        [
+          {
+            "node": "Webhook Response",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "active": false,
+  "settings": {},
+  "versionId": "phantom-shell-ai-ecosystem-v1",
+  "id": "phantom-shell-ai-ecosystem"
+}


### PR DESCRIPTION
## Summary
- add built-in http_request and slack_webhook tools with graceful fallbacks to extend multi-app orchestration
- document sample tool_specs for weaving external APIs and Slack delivery through the agent and n8n flow
- add coverage and dependencies for new connectors while keeping offline behavior intact

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695cfc1340008332b5ba7aa831c76a1c)