### PR TITLE
Add controlled tamper test for export-pr-evidence

### DIFF
--- a/.github/workflows/export-pr-evidence.yml
+++ b/.github/workflows/export-pr-evidence.yml
@@ -7,6 +7,11 @@ on:
         description: Pull request number to export evidence for
         required: true
         type: string
+      tamper_test:
+        description: Tamper downloaded JSON before integrity check (expected failure)
+        required: false
+        default: "false"
+        type: string
 
 permissions:
   contents: read
@@ -146,6 +151,13 @@ jobs:
           if ! [[ "${expected_sha}" =~ ^[0-9a-fA-F]{64}$ ]]; then
             echo "::error::Invalid checksum format in ${sha_path}: '${expected_sha}'"
             exit 1
+          fi
+
+          tamper_raw="${{ inputs.tamper_test }}"
+          tamper_flag="$(printf '%s' "${tamper_raw}" | tr '[:upper:]' '[:lower:]')"
+          if [ "${tamper_flag}" = "true" ] || [ "${tamper_flag}" = "1" ] || [ "${tamper_flag}" = "yes" ]; then
+            printf ' ' >> "${json_path}"
+            echo "::notice::Tamper test enabled; injected one-byte change into $(basename "${json_path}") before checksum comparison."
           fi
 
           actual_sha="$(sha256sum "${json_path}" | awk '{ print $1 }')"

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -1,0 +1,60 @@
+# Operations
+
+## Agent-First Execution Rule
+
+- Use agent-first execution for every task before requesting manual user action.
+- Ask for manual user action only when blocked by permissions, tool limits, or safety constraints.
+- When blocked, state the blocker and the smallest required user step.
+
+## Pre-PR Checklist
+
+- [ ] Before merge, paste the latest `verify-revoke-smoke` timestamp pair from the current run (`verify=<timestamp>`, `revoke=<timestamp>`).
+
+## Branch Protection
+
+- Require status check `verify-revoke-evidence / evidence-gate` on protected branches.
+
+## Permanent PR Evidence Export
+
+- Run `make export-evidence-tuple PR=<pr_number>` to write a timestamped JSON tuple, markdown index, and sha256 file under `/home/jarrettdustinqq/incident-evidence/phantom-shell/`.
+
+## Dispatch PR Evidence Export (CI)
+
+- Trigger the workflow manually: `gh workflow run export-pr-evidence.yml -f pr_number=<pr_number>`.
+- The workflow uploads a `pr-<pr_number>-evidence-tuple` artifact bundle (`.json`, `.md`, `.sha256`) and upserts a single PR comment with the run/artifact location.
+
+## Export Integrity Tamper Test (CI)
+
+- Dispatch tamper test: `gh workflow run export-pr-evidence.yml -f pr_number=<pr_number> -f tamper_test=true`
+- Expected outcome: workflow fails in `Verify uploaded artifact integrity` with `::error::Integrity mismatch ...` and non-zero exit.
+- Dispatch normal test: `gh workflow run export-pr-evidence.yml -f pr_number=<pr_number> -f tamper_test=false`
+- Expected outcome: workflow passes and integrity verification reports `PASS`.
+- Record:
+  - Failing run URL: `<paste failing run URL>`
+  - Mismatch error line: `<paste exact ::error::Integrity mismatch line>`
+  - Passing run URL: `<paste passing run URL>`
+
+## 3-Minute Evidence Gate Proof
+
+1. Edit the PR body with this stale-test block and save:
+
+```text
+verify-revoke-smoke:
+verify=2026-01-01T00:00:00Z
+revoke=2026-01-01T00:05:00Z
+- [x] verify-revoke-smoke evidence pair attached in exact format
+```
+
+Expected: `verify-revoke-evidence / evidence-gate` fails.
+
+2. Run `make verify-revoke-smoke`, then use the current run timestamps: `verify=<rotate_plan_ts>` and `revoke=<rotate_exec_ts>`.
+3. Replace the PR body with this fresh-test block (using your current run values) and save:
+
+```text
+verify-revoke-smoke:
+verify=<rotate_plan_ts>
+revoke=<rotate_exec_ts>
+- [x] verify-revoke-smoke evidence pair attached in exact format
+```
+
+Expected: `verify-revoke-evidence / evidence-gate` passes.


### PR DESCRIPTION
## Summary
- add workflow_dispatch input `tamper_test` to export-pr-evidence workflow
- when enabled, apply a one-byte tamper before checksum verification to force mismatch
- add OPERATIONS.md tamper-test dispatch commands and evidence capture record section

## Validation
- workflow logic reviewed in branch
- end-to-end dispatch validation will be captured after merge