### PR TITLE
Record export tamper-test evidence in operations runbook

### DIFF
--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -29,10 +29,14 @@
 - Expected outcome: workflow fails in `Verify uploaded artifact integrity` with `::error::Integrity mismatch ...` and non-zero exit.
 - Dispatch normal test: `gh workflow run export-pr-evidence.yml -f pr_number=<pr_number> -f tamper_test=false`
 - Expected outcome: workflow passes and integrity verification reports `PASS`.
-- Record:
+- Record template:
   - Failing run URL: `<paste failing run URL>`
-  - Mismatch error line: `<paste exact ::error::Integrity mismatch line>`
+  - Mismatch error line: `<paste exact mismatch error line>`
   - Passing run URL: `<paste passing run URL>`
+- Example record (PR #11, 2026-02-27):
+  - Failing run URL: `https://github.com/jarrettdustinqq/phantom-shell/actions/runs/22468354892`
+  - Mismatch error line: `##[error]Integrity mismatch for pr-11-evidence-tuple-20260227T010934Z.json: expected 5bbd5405417288333a0c418f29af35740618bf9e668ee29ffd4f17d19ba0f8cb, got 9d4127800e3a03efacb064ae9056e3a9462d2356759bfa8ad93eee5c65eb8c2c`
+  - Passing run URL: `https://github.com/jarrettdustinqq/phantom-shell/actions/runs/22468366671`
 
 ## 3-Minute Evidence Gate Proof
 


### PR DESCRIPTION
## Summary
- replace tamper-test record placeholders with a template + concrete PR #11 example
- include failing run URL, exact mismatch error line, and passing run URL

## Evidence source
- failing run: https://github.com/jarrettdustinqq/phantom-shell/actions/runs/22468354892
- passing run: https://github.com/jarrettdustinqq/phantom-shell/actions/runs/22468366671