### PR TITLE
Add deterministic Lennox Kodex terminal reinstall workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,12 @@ Automation shell for funnel and operations tasks, with machine-checkable configu
 make verify
 make test
 ```
+
+
+## Reinstall
+
+```bash
+./scripts/reinstall_lennox_kodex_terminal.sh
+```
+
+See `docs/reinstall_lennox_kodex_terminal.md` for the full runbook.

--- a/docs/reinstall_lennox_kodex_terminal.md
+++ b/docs/reinstall_lennox_kodex_terminal.md
@@ -1,0 +1,24 @@
+# Lennox Kodex terminal reinstall (laptop)
+
+Use this runbook when you want a clean reinstall of your local Codex terminal environment.
+
+## Quick start
+
+```bash
+./scripts/reinstall_lennox_kodex_terminal.sh
+```
+
+## Objective alignment
+
+This reinstall flow keeps your stack deterministic and ready for an autonomous AI ecosystem:
+
+- Single local control point for tools and memory (`phantom-shell` repo).
+- Verification gates on every reinstall (`make verify`, `make test`).
+- Action logging discipline to support goal tracking and financial-asset growth experiments.
+
+## Post-install operating loop
+
+1. Define the current revenue or asset objective in `init.txt`.
+2. Run `make verify`.
+3. Run the loop workflow and track measurable deltas.
+4. Keep only validated automations in the active stack.

--- a/scripts/reinstall_lennox_kodex_terminal.sh
+++ b/scripts/reinstall_lennox_kodex_terminal.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Reinstall Codex terminal tooling on macOS/Linux in an auditable way.
+# This script does not auto-run privileged commands; it prints them.
+
+OS_NAME="$(uname -s)"
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+VENV_DIR="${ROOT_DIR}/.venv"
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "ERROR: missing required command '$1'" >&2
+    return 1
+  fi
+}
+
+print_header() {
+  echo "== Lennox Kodex Terminal Reinstall =="
+  echo "Repo: ${ROOT_DIR}"
+  echo "OS: ${OS_NAME}"
+}
+
+print_os_packages() {
+  echo
+  echo "[1/5] System dependencies"
+  if [[ "${OS_NAME}" == "Darwin" ]]; then
+    cat <<'PKG'
+Run manually if needed:
+  brew update
+  brew install git python@3.11 ripgrep make
+PKG
+  elif [[ "${OS_NAME}" == "Linux" ]]; then
+    cat <<'PKG'
+Run manually if needed:
+  sudo apt-get update
+  sudo apt-get install -y git python3 python3-venv python3-pip ripgrep make
+PKG
+  else
+    echo "Unsupported OS: ${OS_NAME}. Install git, python3, venv, pip, ripgrep, make manually."
+  fi
+}
+
+rebuild_venv() {
+  echo
+  echo "[2/5] Rebuilding Python virtual environment"
+  require_cmd python3
+  rm -rf "${VENV_DIR}"
+  python3 -m venv "${VENV_DIR}"
+  # shellcheck disable=SC1091
+  source "${VENV_DIR}/bin/activate"
+  pip install --upgrade pip
+  pip install -r "${ROOT_DIR}/requirements.txt"
+}
+
+verify_repo() {
+  echo
+  echo "[3/5] Running repository verification"
+  # shellcheck disable=SC1091
+  source "${VENV_DIR}/bin/activate"
+  make -C "${ROOT_DIR}" verify
+  make -C "${ROOT_DIR}" test
+}
+
+print_connectivity_plan() {
+  echo
+  echo "[4/5] App + AI ecosystem wiring checklist"
+  cat <<'PLAN'
+- Connect Codex/OpenAI API key using environment variables only (no plaintext in repo).
+- Add broker endpoints for finance, notes, and task systems via stable wrappers.
+- Log every autonomous action with UTC timestamp and verification state.
+- Keep one objective queue: income growth experiments with measurable deltas.
+PLAN
+}
+
+print_next_steps() {
+  echo
+  echo "[5/5] Next steps"
+  cat <<'NEXT'
+1. Activate environment:
+   source .venv/bin/activate
+2. Start your terminal workflow from this repository root.
+3. Keep objectives in init.txt and run make verify before each autonomous loop.
+NEXT
+}
+
+main() {
+  print_header
+  print_os_packages
+  rebuild_venv
+  verify_repo
+  print_connectivity_plan
+  print_next_steps
+  echo
+  echo "Reinstall workflow completed."
+}
+
+main "$@"

--- a/tests/test_reinstall_assets.py
+++ b/tests/test_reinstall_assets.py
@@ -1,0 +1,29 @@
+import os
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class ReinstallAssetsTests(unittest.TestCase):
+    def test_reinstall_script_exists_and_is_executable(self) -> None:
+        script = ROOT / "scripts" / "reinstall_lennox_kodex_terminal.sh"
+        self.assertTrue(script.exists())
+        self.assertTrue(os.access(script, os.X_OK))
+
+    def test_reinstall_script_has_stable_help_output(self) -> None:
+        proc = subprocess.run(
+            ["bash", "-n", "scripts/reinstall_lennox_kodex_terminal.sh"],
+            cwd=ROOT,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(proc.returncode, 0, msg=proc.stdout + "\n" + proc.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Provide a deterministic, auditable reinstall flow for the Lennox Kodex / Codex terminal to ensure consistent local environment setup across machines. 
- Align the reinstall process with the repository's autonomous execution goals and verification-first philosophy. 
- Surface a lightweight app/AI wiring checklist to help connect API keys and broker endpoints safely while preserving execution logs and objectives.

### Description
- Add `scripts/reinstall_lennox_kodex_terminal.sh` which rebuilds a `.venv`, installs `requirements.txt`, runs repository verification, and prints a stepwise reinstall and connectivity plan. 
- Add `docs/reinstall_lennox_kodex_terminal.md` containing a runbook, quick-start usage, and a post-install operating loop aligned to measurable objectives. 
- Update `README.md` with a `Reinstall` entrypoint that references the new script and runbook. 
- Add `tests/test_reinstall_assets.py` to assert the script exists, is executable, and passes shell syntax checking with `bash -n`.

### Testing
- Ran `make verify` which executed `scripts/verify_config.py` and returned success. 
- Ran `make test` which executed the test suite including the new `tests/test_reinstall_assets.py` and all tests passed (`OK`). 
- The repository verification and unit tests completed without failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9a3440c208332aac13c8540a38da6)

------

verify-revoke-smoke:
verify=2026-04-17T14:35:14Z
revoke=2026-04-17T14:40:14Z
- [x] verify-revoke-smoke evidence pair attached in exact format